### PR TITLE
Added missing require statement to Word2Vec example

### DIFF
--- a/src/dl4clj/examples/word2vec/word2vec_raw_text_example.clj
+++ b/src/dl4clj/examples/word2vec/word2vec_raw_text_example.clj
@@ -12,7 +12,7 @@
             [dl4clj.models.sequencevectors.sequence-vectors :refer (fit)]
             [dl4clj.models.embeddings.wordvectors.word-vectors :refer (similarity words-nearest get-word-vector)]
             [dl4clj.models.word2vec.word2vec :refer (word2vec)]
-            [dl4clj.plot.barnes-hut-tsne :refer ()]
+            [dl4clj.plot.barnes-hut-tsne :refer (barnes-hut-tsne)]
             [dl4clj.models.embeddings.loader.word-vector-serializer :refer (write-word-vectors load-txt-vectors)]))
 
 ;;; This example code follows the word2vec code snippets at http://deeplearning4j.org/word2vec.html#just


### PR DESCRIPTION
Word2vec example was missing `barnes-hut-tsne/barnes-hut-tsne`. 

Thanks for starting the port/wrapper of Deeplearning4j to Clojure! I'm a huge fan of Clojure and this is filling a clear gap in the ecosystem.
