### PR TITLE
Typo: "(. backpropGradient" -> : "(.backpropGradient"

### DIFF
--- a/src/dl4clj/nn/api/layer.clj
+++ b/src/dl4clj/nn/api/layer.clj
@@ -32,7 +32,7 @@
 (defn backprop-gradient
   "Calculate the gradient relative to the error in the next layer"
   [^Layer this ^INDArray epsilon]
-  (. backpropGradient this epsilon))
+  (.backpropGradient this epsilon))
 
 (defn calc-gradient
   "Calculate the gradient"


### PR DESCRIPTION
Fixed a typo in `dl4clj.nn.api.layer`:

`backprop-gradient` had a space between the `.` and the method name, `backpropGradient`. 
