### PR TITLE
Namespace / filename consistency in Graves example

### DIFF
--- a/src/dl4clj/examples/rnn/graves_lstm_char_modelling_example.clj
+++ b/src/dl4clj/examples/rnn/graves_lstm_char_modelling_example.clj
@@ -7,14 +7,12 @@ GravesLSTM Character modelling example
 For general instructions using deeplearning4j's implementation of recurrent neural nets see http://deeplearning4j.org/usingrnns.html
 "}
   dl4clj.examples.rnn.graves-lstm-char-modelling-example
-  (:require [dl4clj.examples.rnn.graves-lstm-char-modelling-example.tools :refer :all]
+  (:require [dl4clj.examples.rnn.tools :refer [sample-characters-from-network]]
             [dl4clj.examples.example-utils :refer (shakespeare)]
-            ;; [dl4clj.examples.rnn.lr-character-iterator :refer (lr-character-iterator)]
             [dl4clj.examples.rnn.character-iterator :refer (get-shakespeare-iterator)]
             [nd4clj.linalg.dataset.api.iterator.data-set-iterator :refer (input-columns total-outcomes reset)]
             [dl4clj.nn.conf.layers.graves-lstm]
             [dl4clj.nn.conf.layers.rnn-output-layer]
-            ;; [nd4clj.linalg.factory.nd4j :refer (set-enforce-numerical-stability!)]
             [dl4clj.nn.conf.distribution.uniform-distribution]
             [nd4clj.linalg.lossfunctions.loss-functions]
             [dl4clj.nn.conf.neural-net-configuration :refer (neural-net-configuration)]

--- a/src/dl4clj/examples/rnn/tools.clj
+++ b/src/dl4clj/examples/rnn/tools.clj
@@ -1,5 +1,5 @@
 (ns ^{:doc ""}
-  dl4clj.examples.rnn.graves-lstm-char-modelling-example.tools
+  dl4clj.examples.rnn.tools
   (:require [nd4clj.linalg.dataset.api.iterator.data-set-iterator :refer (input-columns total-outcomes)]
             [nd4clj.linalg.factory.nd4j :refer (zeros)]
             [nd4clj.linalg.api.ndarray.indarray :refer (put-scalar get-double tensor-along-dimension)]


### PR DESCRIPTION
1. Changed name of namespace `dl4clj.examples.rnn.graves-lstm-char-modelling-example.tools` to `dl4clj.examples.rnn.tools` in order to be consistent with the filename.
2. In `graves_lstm_char_modelling_example`, removed commented-out references to unused namespaces in `rnn.graves_lstm_char_modelling_example`.
